### PR TITLE
fix:修复SpringScrollView在302框架上无法正常注册Fabric组件问题

### DIFF
--- a/src/SpringScrollView.js
+++ b/src/SpringScrollView.js
@@ -28,8 +28,10 @@ import type { HeaderStatus } from "./RefreshHeader";
 import { idx } from "./idx";
 import type { Offset, SpringScrollViewPropType } from "./Types";
 import { styles } from "./styles";
+import type { NativeProps as SpringScrollViewViewProps } from './SpringScrollViewNativeComponent';
+import SpringScrollViewNative from './SpringScrollViewNativeComponent';
 
-export class SpringScrollView extends React.PureComponent<SpringScrollViewPropType> {
+export class SpringScrollView extends React.PureComponent<SpringScrollViewViewProps> {
   _offsetY: Animated.Value;
   _offsetX: Animated.Value;
   _offsetYValue: number = 0;
@@ -106,7 +108,7 @@ export class SpringScrollView extends React.PureComponent<SpringScrollViewPropTy
         {...this.props}
         ref={ref => (this._scrollView = ref)}
         style={(Platform.OS === "android" || Platform.OS === "harmony") ? wStyle : { flex: 1 }}
-        onScroll={this._event}
+        onScroll={this._onScroll}
         refreshHeaderHeight={onRefresh ? Refresh.height : 0}
         loadingFooterHeight={onLoading ? Loading.height : 0}
         onLayout={this._onWrapperLayoutChange}
@@ -557,10 +559,6 @@ export class SpringScrollView extends React.PureComponent<SpringScrollViewPropTy
     alwaysBounceVertical: true
   };
 }
-
-const SpringScrollViewNative = Animated.createAnimatedComponent(
-  requireNativeComponent("SpringScrollView", SpringScrollView)
-);
 
 const SpringScrollContentViewNative =
   Platform.OS === "ios" ? requireNativeComponent("SpringScrollContentView") : View;

--- a/src/SpringScrollViewNativeComponent.ts
+++ b/src/SpringScrollViewNativeComponent.ts
@@ -1,0 +1,124 @@
+import * as React from "react";
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { HostComponent, ViewProps,Animated,ViewStyle } from 'react-native';
+
+export interface Offset {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width:number;
+  height:number;
+}
+
+export interface NativeContentOffset {
+  x?: Animated.Value;
+  y?: Animated.Value;
+}
+
+export type RefreshStyle = "topping" | "stickyScrollView" | "stickyContent";
+
+export type LoadingStyle = "bottoming" | "stickyScrollView" | "stickyContent";
+
+export interface ScrollEvent {
+  nativeEvent: {
+    contentOffset: {
+      x: number;
+      y: number;
+    };
+  };
+}
+
+export type HeaderStatus =
+  | "waiting"
+  | "pulling"
+  | "pullingEnough"
+  | "pullingCancel"
+  | "refreshing"
+  | "rebound";
+
+export interface RefreshHeaderPropType {
+  maxHeight: number;
+  offset: Animated.Value;
+}
+export interface RefreshHeaderStateType {
+  status: HeaderStatus;
+}
+export class RefreshHeader extends React.Component<
+  RefreshHeaderPropType,
+  RefreshHeaderStateType
+> {}
+
+export class NormalHeader extends RefreshHeader {}
+
+export type FooterStatus =
+  | "waiting"
+  | "dragging"
+  | "draggingEnough"
+  | "draggingCancel"
+  | "releaseRebound"
+  | "loading"
+  | "rebound"
+  | "allLoaded";
+
+export interface LoadingFooterPropType {
+  maxHeight: number;
+  offset: Animated.Value;
+  bottomOffset: number;
+}
+
+export interface LoadingFooterStateType {
+  status: FooterStatus;
+}
+
+export class LoadingFooter extends React.Component<
+  LoadingFooterPropType,
+  LoadingFooterStateType
+> {}
+
+export class NormalFooter extends LoadingFooter {}
+
+export interface NativeProps extends ViewProps {
+    contentStyle?: ViewStyle;
+    bounces?: boolean;
+    scrollEnabled?: boolean;
+    directionalLockEnabled?: boolean;
+    initialContentOffset?: Offset;
+    showsVerticalScrollIndicator?: boolean;
+    showsHorizontalScrollIndicator?: boolean;
+    refreshHeader?: React.ComponentClass<RefreshHeaderPropType, RefreshHeaderStateType>;
+    loadingFooter?: React.ComponentClass<LoadingFooterPropType, LoadingFooterStateType>;
+    onRefresh?: () => any;
+    onLoading?: () => any;
+    allLoaded?: boolean;
+    textInputRefs?: any[];
+    inputToolBarHeight?: number;
+    tapToHideKeyboard?: boolean;
+    pagingEnabled?: boolean;
+    pageSize?: Size;
+    dragToHideKeyboard?: boolean;
+    onTouchBegin?: () => any;
+    onTouchEnd?: () => any;
+    onTouchFinish?: () => any;
+    inverted?: boolean;
+    onMomentumScrollBegin?: () => any;
+    onMomentumScrollEnd?: () => any;
+    onScroll?: (evt: ScrollEvent) => any;
+    onNativeContentOffsetExtract?: NativeContentOffset;
+    onSizeChange?: (size:Size) => any;
+    onContentSizeChange?: (size: Size) => any;
+    onScrollBeginDrag?: () => any;
+    scrollTo(offset: Offset, animated?: boolean): Promise<void>;
+    scroll(offset: Offset, animated?: boolean): Promise<void>;
+    scrollToBegin(animated?: boolean): Promise<void>;
+    scrollToEnd(animated?: boolean): Promise<void>;
+    endRefresh(): void;
+    endLoading(): void;
+    beginRefresh(): Promise<any>;
+  }
+  
+  
+  export default codegenNativeComponent<NativeProps>(
+    'SpringScrollView'
+  ) as HostComponent<NativeProps>;


### PR DESCRIPTION
# Summary

- fix:修复SpringScrollView在302框架上无法正常注册Fabric组件问题
- Close: #18 

## Test Plan

- 1.编译运行react-native-spring-scrollview的demo，查看是否正常渲染
- 2.已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
