### PR TITLE
fix:修复折叠屏屏幕自适应问题

### DIFF
--- a/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.cpp
+++ b/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.cpp
@@ -226,8 +226,13 @@ void SpringScrollViewComponentInstance::onStateChanged(SharedConcreteState const
                            : stateData.getContentSize().height;
     this->getLocalRootArkUINode().setContentSize(
         {static_cast<float>(stateData.getContentSize().width), static_cast<float>(tempHeight)});
-    DLOG(INFO) << "SpringScrollViewComponentInstance onStateChanged h:" << tempHeight
-               << " w:" << m_layoutMetrics.frame.size.width;
+    DLOG(INFO) << "SpringScrollViewComponentInstance onStateChanged content_h:" << stateData.getContentSize().height
+               << " content_w:" << stateData.getContentSize().width << " h:"<<m_layoutMetrics.frame.size.height << " w:" << m_layoutMetrics.frame.size.width;
+    if(!this->firstShowUI){    
+    this->getLocalRootArkUINode().setChildHeight(m_layoutMetrics.frame.size.height);
+    this->getLocalRootArkUINode().setChildWidth(m_layoutMetrics.frame.size.width);
+    }
+    this->firstShowUI = false;
 }
 
 bool SpringScrollViewComponentInstance::isHandlingTouches() const { return this->swiperStatus; }

--- a/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.h
+++ b/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.h
@@ -56,6 +56,7 @@ private:
     facebook::react::Size m_containerSize;
     facebook::react::Size m_contentSize;
     std::weak_ptr<NativeAnimatedTurboModule> m_springNativeAnimatedTurboModule{};
+    bool firstShowUI = true;
 public:
     SpringScrollViewComponentInstance(Context context);
     void onChildInserted(ComponentInstance::Shared const &childComponentInstance, std::size_t index) override;


### PR DESCRIPTION
# Summary

- fix:修复折叠屏屏幕自适应问题
- Close: #30 


## Test Plan

- 运行以下代码在折叠屏设备上，并设置分屏模式，观察布局自适应变化
![image](https://github.com/user-attachments/assets/21ef1c14-bb2d-470c-83be-c651dfb3f4aa)
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)