### PR TITLE
fix:修复当内容宽度小于spring-scrollview设置的style宽度时滑动异常问题

### DIFF
--- a/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.cpp
+++ b/harmony/spring_scrollview/src/main/cpp/SpringScrollViewComponentInstance.cpp
@@ -224,8 +224,11 @@ void SpringScrollViewComponentInstance::onStateChanged(SharedConcreteState const
     float tempHeight = (stateData.getContentSize().height < m_layoutMetrics.frame.size.height)
                            ? m_layoutMetrics.frame.size.height
                            : stateData.getContentSize().height;
+    float tempWidth = (stateData.getContentSize().width < m_layoutMetrics.frame.size.width)
+                           ? m_layoutMetrics.frame.size.width
+                           : stateData.getContentSize().width;
     this->getLocalRootArkUINode().setContentSize(
-        {static_cast<float>(stateData.getContentSize().width), static_cast<float>(tempHeight)});
+        {tempWidth, tempHeight});
     DLOG(INFO) << "SpringScrollViewComponentInstance onStateChanged content_h:" << stateData.getContentSize().height
                << " content_w:" << stateData.getContentSize().width << " h:"<<m_layoutMetrics.frame.size.height << " w:" << m_layoutMetrics.frame.size.width;
     if(!this->firstShowUI){    


### PR DESCRIPTION
# Summary

- fix:修复当内容宽度小于spring-scrollview设置的style宽度时滑动异常问题
-Close: #32 


## Test Plan

- 1.运行以下代码，可以正常上下滑动
![image](https://github.com/user-attachments/assets/21ef1c14-bb2d-470c-83be-c651dfb3f4aa)
- 2.已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
