### PR TITLE
fix:修复下拉刷新手势速度触发快时加载动画渲染异常问题

### DIFF
--- a/harmony/spring_scrollview/src/main/cpp/SpringScrollViewNode.cpp
+++ b/harmony/spring_scrollview/src/main/cpp/SpringScrollViewNode.cpp
@@ -213,6 +213,9 @@ void SpringScrollViewNode::onUp(ArkUI_GestureEvent *evt) {
     if (shouldRefresh()) {
         refreshStatus = "refreshing";
         contentInsets.top = refreshHeaderHeight;
+        if (vy > 0) {
+            vy = 0;
+        }
     }
     if (shouldLoad()) {
         loadingStatus = "loading";


### PR DESCRIPTION
# Summary

- fix:修复下拉刷新手势速度触发快时加载动画渲染异常问题
- Close: #45 

## Test Plan

- 测试用例ComplexBouncesTrueExample下拉刷新
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)