### PR TITLE
fix：initialContentOffset属性无效，添加setContentOffset方法至insertChild中

### DIFF
--- a/harmony/spring_scrollview/src/main/cpp/SpringScrollViewNode.cpp
+++ b/harmony/spring_scrollview/src/main/cpp/SpringScrollViewNode.cpp
@@ -82,6 +82,7 @@ void SpringScrollViewNode::insertChild(ArkUINode &child, std::size_t index) {
         NativeNodeApi::getInstance()->insertChildAt(m_stackArkUINodeHandle, child.getArkUINodeHandle(), index);
         this->setChildWidth(m_scrollNodeDelegate->getLayoutSize().width);
         this->setChildHeight(m_scrollNodeDelegate->getLayoutSize().height);
+        this->setContentOffset(initialContentOffset.x, initialContentOffset.y);
         this->recordEventModel = std::make_shared<SpringScrollViewEvent>(5);
         this->recordEventModel->setNodeHandle(m_stackArkUINodeHandle);
         this->recordEventModel->setEventSpringScrollViewNodeDelegate(this->m_scrollNodeDelegate);


### PR DESCRIPTION
Signed-off-by: zeng_qilin<zengqiling1@huawei-partners.com>

<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

initialContentOffset属性无效，添加setContentOffset方法至insertChild中

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
